### PR TITLE
chore: loosen huggingface-hub constraint to >=0.36.0,<2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 gguf==0.17.1
 safetensors>=0.4.3
 torch>=2.7.0
-huggingface-hub~=0.36.0
+huggingface-hub>=0.36.0,<2.0


### PR DESCRIPTION
## What

Loosen the `huggingface-hub` pin in `requirements.txt`:

```diff
-huggingface-hub~=0.36.0
+huggingface-hub>=0.36.0,<2.0
```

## Why

`~=0.36.0` resolves to **0.36.x only**. The new range allows newer releases — including the **1.x** line (latest 1.16.4 at time of writing) — while the `<2.0` cap blocks an as-yet-unreleased, unreviewed 2.0 major where breaking changes would be expected.

## Compatibility verification

The project uses only three `huggingface-hub` symbols, all in `model_police/model_police.py`:

| Symbol | 0.36.1 (floor) | 1.16.4 (top of range) |
|---|---|---|
| `hf_hub_url` | ✅ | ✅ |
| `snapshot_download` | ✅ | ✅ |
| `disable_progress_bars` | ✅ | ✅ |

- All three imported and the call sites matched signatures on both ends of the range.
- `hf_hub_url` behavior check produced the expected URL on 1.16.4.
- **Import path note:** `disable_progress_bars` is kept on the `huggingface_hub.utils` path. The top-level `huggingface_hub.disable_progress_bars` export only exists in 1.x, so importing it there would break on the 0.36.x floor. The `.utils` path works across the whole range.

## Integration & real-model CLI test

Fresh-venv installs and a real download were run against the new range:

- **Base install** (`pip install -e .`) → resolves hub **1.16.4**, no conflicts.
- **With `requirements-diffusers.txt`** → resolver pulls hub back to **0.36.2** (current `diffusers` caps hub < 1.0); `pip check` reports no broken requirements. So the full install effectively stays on 0.36.x while the base install can move to 1.x — both verified working.
- **Real-model CLI test** on hub **1.16.4** against `alvdansen/frosting_lane_flux` (the repo from the code's own docstring):
  - `checkpoint classify alvdansen/frosting_lane_flux` → exercises `snapshot_download`; downloaded and classified correctly (Flux LoRA, 988 keys, 100% coverage).
  - `checkpoint classify "alvdansen/frosting_lane_flux:flux_dev_frostinglane_araminta_k.safetensors"` → exercises `hf_hub_url`; built the resolve URL, pulled 172 MB, identical classification.

## Notes

- No source code changes — only the dependency constraint.
- `<2.0` was chosen to avoid auto-upgrading into an untested future major version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)