### PR TITLE
fix(inspect): keep layer_names_with_shapes on checkpoint when lora detection fails

### DIFF
--- a/model_police/model_police.py
+++ b/model_police/model_police.py
@@ -491,22 +491,25 @@ class ModelPolice:
                 state_dict = checkpoint["state_dict"]
 
                 state_dict_shapes = self.get_state_dict_shapes(state_dict)
-                is_lora = self.is_lora(state_dict_shapes)
 
-                # layer_names_with_shapes creation
-                if is_lora:
-                    # only lora up and down suffixes are considered
-                    layer_names_with_shapes = self.get_layer_names_with_shapes_from_lora(state_dict_shapes)
-                else:
-                    layer_names_with_shapes = self.state_dict_shapes_to_list(state_dict_shapes)
-
+                # store the raw key list before lora detection, so that consumers can
+                # still report the checkpoint keys when detection fails (e.g. mixed
+                # lora and full keys)
                 checkpoint.update({
                     "num_keys": len(state_dict_shapes),
-                    "is_lora": is_lora,
-                    "layer_names_with_shapes": layer_names_with_shapes,
+                    "is_lora": None,
+                    "layer_names_with_shapes": self.state_dict_shapes_to_list(state_dict_shapes),
                     "model_components": [],
                     "lora_model_family": {},
                 })
+
+                is_lora = self.is_lora(state_dict_shapes)
+                checkpoint["is_lora"] = is_lora
+
+                if is_lora:
+                    # only lora up and down suffixes are considered
+                    checkpoint["layer_names_with_shapes"] = self.get_layer_names_with_shapes_from_lora(state_dict_shapes)
+                layer_names_with_shapes = checkpoint["layer_names_with_shapes"]
 
                 if is_lora:
                     # lora classification

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,0 +1,62 @@
+import pytest
+import torch
+
+from safetensors.torch import save_file
+
+from model_police import ModelPolice
+
+
+@pytest.fixture(scope="module")
+def police():
+    return ModelPolice()
+
+
+def make_checkpoint(tmp_path, state_dict):
+    checkpoint_path = tmp_path / "model.safetensors"
+    save_file(state_dict, str(checkpoint_path))
+    return checkpoint_path
+
+
+def test_inspect_keeps_layer_names_on_mixed_keys_error(police, tmp_path):
+    """When is_lora() fails with mixed lora/full keys, the checkpoint must still
+    expose layer_names_with_shapes so consumers (e.g. Sentry attachments) can
+    report which keys caused the failure."""
+    lora_down = police._lora_down_suffixes[0]
+    lora_up = police._lora_up_suffixes[0]
+
+    checkpoint_path = make_checkpoint(tmp_path, {
+        f"transformer.blocks.0.attn.to_q{lora_down}": torch.zeros(4, 64),
+        f"transformer.blocks.0.attn.to_q{lora_up}": torch.zeros(64, 4),
+        "transformer.blocks.0.attn.to_q.weight": torch.zeros(64, 64),
+    })
+
+    full_models, checkpoint_list, error = police.inspect(checkpoint_path)
+
+    assert error == "Mixed lora keys and full keys"
+    assert len(checkpoint_list) == 1
+
+    layer_names = checkpoint_list[0]["layer_names_with_shapes"]
+    assert len(layer_names) == 3
+    assert f"transformer.blocks.0.attn.to_q{lora_down},4,64" in layer_names
+    assert "transformer.blocks.0.attn.to_q.weight,64,64" in layer_names
+
+
+def test_inspect_lora_layer_names_use_lora_format(police, tmp_path):
+    """For a valid LoRA, layer_names_with_shapes must keep the merged
+    lora format (key,in_features,out_features), not the raw key list."""
+    lora_down = police._lora_down_suffixes[0]
+    lora_up = police._lora_up_suffixes[0]
+
+    checkpoint_path = make_checkpoint(tmp_path, {
+        f"transformer.blocks.0.attn.to_q{lora_down}": torch.zeros(4, 64),
+        f"transformer.blocks.0.attn.to_q{lora_up}": torch.zeros(64, 4),
+    })
+
+    full_models, checkpoint_list, error = police.inspect(checkpoint_path)
+
+    assert error is None
+    assert len(checkpoint_list) == 1
+    assert checkpoint_list[0]["is_lora"] is True
+    assert checkpoint_list[0]["layer_names_with_shapes"] == [
+        "transformer.blocks.0.attn.to_q,64,64",
+    ]


### PR DESCRIPTION
## Source

Sentry alert from the upload model validator: `ModelPolice raised an error: Mixed lora keys and full keys` — the `<model>_keys.csv` attachment on the event was **empty**, making it impossible to see which keys caused the rejection or to update the dictionaries/ignore lists accordingly.

## Bug

`inspect()` only enriched each checkpoint entry with `layer_names_with_shapes` *after* `is_lora()` succeeded. When `is_lora()` raised (mixed lora/full keys), the catch-all in `inspect()` returned the checkpoint list with entries containing only `{subfolder, files, state_dict}`. Phoenix's `get_checkpoint_keys_from_exception` (in `upload_model_validator/app.py`) then read `checkpoint.get("layer_names_with_shapes", [])` → empty CSV attached to Sentry.

## Fix

Store the raw key list (`state_dict_shapes_to_list`) on the checkpoint **before** lora detection, and overwrite it with the lora-formatted list only once detection succeeds. `is_lora` is initialized to `None` before detection so the field always exists; the error path leaves it `None` (consumers only read it when `error is None`).

This also covers failures inside `get_layer_names_with_shapes_from_lora` (up/down count mismatch): raw keys remain available there too.

## Tests

Added `tests/test_inspect.py` (first pytest suite in the repo — run with `python -m pytest tests/`, requires `pytest` which is not in `requirements.txt`):

- `test_inspect_keeps_layer_names_on_mixed_keys_error` — reproduces the Sentry case: written first, failed with `KeyError: 'layer_names_with_shapes'` before the fix, passes after.
- `test_inspect_lora_layer_names_use_lora_format` — guards that valid LoRAs still get the merged `key,in,out` format.

Also verified end-to-end against a copy of phoenix's attachment-extraction logic: the mixed-keys case now yields a CSV with all 3 keys+shapes instead of 0 bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small reordering in inspect enrichment with no auth or data-path changes; behavior improves error reporting while preserving success-path LoRA formatting.
> 
> **Overview**
> **`inspect()`** now always populates each checkpoint with **`layer_names_with_shapes`** (raw `key,shape` list) and **`is_lora: None`** *before* calling **`is_lora()`**, so error paths (e.g. mixed LoRA/full keys or up/down mismatch) still return key metadata for Sentry/CSV attachments instead of an empty list.
> 
> On successful LoRA detection, **`is_lora`** is set and **`layer_names_with_shapes`** is replaced with the merged LoRA format as before.
> 
> Adds **`tests/test_inspect.py`** with pytest coverage for the mixed-keys failure case and valid LoRA formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc1ca3508ced759828669782609d495b656a209d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->